### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/fake/fake.cpp
+++ b/fake/fake.cpp
@@ -344,6 +344,7 @@ bool readfile(const char * filename, int addsize, char * & buf, int & filesize)
 	if (fread(tmpbuf, size, 1, fp) != 1)
 	{
 		printf("read %s fail\n", filename);
+		free(tmpbuf);
 		return false;
 	}
 	fclose(fp);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'tmpbuf' pointer. A memory leak is possible. fake.cpp 347